### PR TITLE
Добавлен docker-maven-plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM java:8
+ADD target/choreography-orchestrator.jar /app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,9 @@
 
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
         <docker-maven-plugin.version>1.0.0</docker-maven-plugin.version>
+
+        <!-- Существует переменная среды DOCKER_HOST, однако в ней помимо ip указан также порт и протокол.
+        В данную переменную нужно скопировать только ip докер хоста -->
         <docker.ip>192.168.99.100</docker.ip>
     </properties>
 
@@ -162,13 +165,13 @@
 
                 <configuration>
 
-                    <image>${project.artifactId}_${project.version}_${scmBranch}_${buildNumber}</image>
-                    <newName>${docker.ip}:5000/${project.artifactId}_${buildNumber}</newName>
+                    <image>${project.artifactId}</image>
+                    <newName>${docker.ip}:5000/${scmBranch}_${project.version}</newName>
 
-                    <imageName>${project.artifactId}_${project.version}_${scmBranch}_${buildNumber}</imageName>
+                    <imageName>${project.artifactId}</imageName>
                     <dockerDirectory>.</dockerDirectory>
                     <dockerHost>https://${docker.ip}:2376</dockerHost>
-                    <dockerCertPath>C:\Users\Edik\.docker\machine\machines\default</dockerCertPath>
+                    <dockerCertPath>${env.DOCKER_CERT_PATH}</dockerCertPath>
                     <resources>
                         <resource>
                             <directory>${project.build.directory}</directory>
@@ -190,7 +193,7 @@
                     push может быть осуществлен после запуска Docker Registry
                     <execution>
                         <configuration>
-                            <imageName>${docker.ip}:5000/${project.artifactId}_${buildNumber}</imageName>
+                            <imageName>${docker.ip}:5000/${scmBranch}_${project.version}</imageName>
                         </configuration>
                         <phase>deploy</phase>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,19 @@
         <validation-api.version>2.0.1.Final</validation-api.version>
         <org.springframework.boot.version>2.2.0.RELEASE</org.springframework.boot.version>
         <org.apache.maven.plugins.version>2.19.1</org.apache.maven.plugins.version>
+
+        <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
+        <docker-maven-plugin.version>1.0.0</docker-maven-plugin.version>
+        <docker.ip>192.168.99.100</docker.ip>
     </properties>
+
+    <!-- Нужен для buildnumber-maven-plugin. Необходимо указать адрес репозитория -->
+    <scm>
+        <connection>scm:git:https://https://github.com/microservices-course-itmo/saga.git</connection>
+        <developerConnection>scm:git:https://https://github.com/microservices-course-itmo/saga.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://https://github.com/microservices-course-itmo/saga.git</url>
+    </scm>
 
     <dependencies>
         <dependency>
@@ -124,6 +136,71 @@
                     </archive>
                 </configuration>
             </plugin>
+
+            <!-- Нужен для определения текущей ветки(scmBranch) и хэша текущего коммита(buildNumber) -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <version>${buildnumber-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <doCheck>false</doCheck>
+                    <doUpdate>false</doUpdate>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>${docker-maven-plugin.version}</version>
+
+                <configuration>
+
+                    <image>${project.artifactId}_${project.version}_${scmBranch}_${buildNumber}</image>
+                    <newName>${docker.ip}:5000/${project.artifactId}_${buildNumber}</newName>
+
+                    <imageName>${project.artifactId}_${project.version}_${scmBranch}_${buildNumber}</imageName>
+                    <dockerDirectory>.</dockerDirectory>
+                    <dockerHost>https://${docker.ip}:2376</dockerHost>
+                    <dockerCertPath>C:\Users\Edik\.docker\machine\machines\default</dockerCertPath>
+                    <resources>
+                        <resource>
+                            <directory>${project.build.directory}</directory>
+                            <include>${project.build.finalName}.jar</include>
+                        </resource>
+                    </resources>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>docker image build</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>tag</goal>
+                        </goals>
+                    </execution>
+                    <!--
+                    push может быть осуществлен после запуска Docker Registry
+                    <execution>
+                        <configuration>
+                            <imageName>${docker.ip}:5000/${project.artifactId}_${buildNumber}</imageName>
+                        </configuration>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>push</goal>
+                        </goals>
+                    </execution>
+                    -->
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
В качестве разделителя в названии image (название в формате idАртефакта_версия_текущаяВетка_хэшТекущегоКоммита) используется "_", потому что другие разделители либо не поддерживаются, либо интерпретируются докером как ссылка на репозиторий. Image успешно билдится и, при условии запущенного Docker Registry, пушится. Подробнее см. https://www.notion.so/Maven-Docker-Docker-Registry-JFrog-Artifactory-Github-d810d9ea7c9f44cc9dd42be62dd9c42c